### PR TITLE
crc32: Per the PPC64 ABI, v20-v31 are non-volatile registers

### DIFF
--- a/crc32.S
+++ b/crc32.S
@@ -89,6 +89,31 @@ FUNC_START(__crc32_vpmsum)
 	std	r26,-48(r1)
 	std	r25,-56(r1)
 
+	li 	r31, -256
+	stvx 	v20, r31, r1
+	li 	r31, -240
+	stvx 	v21, r31, r1
+	li 	r31, -224
+	stvx 	v22, r31, r1
+	li 	r31, -208
+	stvx 	v23, r31, r1
+	li 	r31, -192
+	stvx 	v24, r31, r1
+	li 	r31, -176
+	stvx 	v25, r31, r1
+	li 	r31, -160
+	stvx 	v26, r31, r1
+	li 	r31, -144
+	stvx 	v27, r31, r1
+	li 	r31, -128
+	stvx 	v28, r31, r1
+	li 	r31, -112
+	stvx 	v29, r31, r1
+	li 	r31, -96
+	stvx 	v30, r31, r1
+	li 	r31, -80
+	stvx 	v31, r31, r1
+
 	li	off16,16
 	li	off32,32
 	li	off48,48
@@ -569,6 +594,31 @@ FUNC_START(__crc32_vpmsum)
 
 	/* Get it into r3 */
 	MFVRD(r3, v0)
+
+	li 	r31, -256
+	lvx 	v20, r31, r1
+	li 	r31, -240
+	lvx 	v21, r31, r1
+	li 	r31, -224
+	lvx 	v22, r31, r1
+	li 	r31, -208
+	lvx 	v23, r31, r1
+	li 	r31, -192
+	lvx 	v24, r31, r1
+	li 	r31, -176
+	lvx 	v25, r31, r1
+	li 	r31, -160
+	lvx 	v26, r31, r1
+	li 	r31, -144
+	lvx 	v27, r31, r1
+	li 	r31, -128
+	lvx 	v28, r31, r1
+	li 	r31, -112
+	lvx 	v29, r31, r1
+	li 	r31, -96
+	lvx 	v30, r31, r1
+	li 	r31, -80
+	lvx 	v31, r31, r1
 
 	ld	r31,-8(r1)
 	ld	r30,-16(r1)


### PR DESCRIPTION
See http://refspecs.linuxfoundation.org/ELF/ppc64/PPC-elf64abi.html#REG for calling convention.

In experiments under GDB, we see that after crc32_vpmsum is called that registers v20-v31 are modified. We discovered this issue after integrating the crc32_vpmsum code into our C++ code base which targeted POWER8 for code generation, see https://jira.mongodb.org/browse/SERVER-22773 for repro.

Signed-off-by: Mark Benvenuto mark.benvenuto@mongodb.com
Signed-off-by: Jason Carey jason.carey@mongodb.com
