### PR TITLE
add clang compatibility on C implementation including with Big Endian

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,7 @@ crc32_two_implementations: crc32k_wrapper.o crc32k.o vec_crc32_ethernet.o
 test: crc32_test
 	set -e ; \
 	for len in `seq 0 257`  32767 32768 32769 65535 65536 65537 ; do \
+		echo len=$$len; \
 		./crc32_test  $${RANDOM} $$len $${RANDOM} ; \
 	done ; \
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 ORIG_CFLAGS:= $(CFLAGS)
 
-CFLAGS+=-m64 -g -O2 -mcpu=power8 -mpower8-vector -Wall
+CFLAGS+=-m64 -g -O2 -mcpu=power8 -mcrypto -mpower8-vector -maltivec -mvsx -Wall
 ASFLAGS=-m64 -g
 LDFLAGS=-m64 -g -static
 

--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ crc32_two_implementations: crc32k_wrapper.o crc32k.o vec_crc32_ethernet.o
 # implementation has boundaries on datasizes 16 and 256, 32768 so ensure coverage and correctness
 test: crc32_test
 	set -e ; \
-	for len in `seq 0 257`  32767 32768 32769 65535 65536 65537 ; do \
+	for len in `seq 0 300` `seq 32750 32780` `seq 65515 65560` ; do \
 		echo len=$$len; \
 		./crc32_test  $${RANDOM} $$len $${RANDOM} ; \
 	done ; \

--- a/barrett_reduction.S
+++ b/barrett_reduction.S
@@ -14,7 +14,13 @@
  *     any later version, or
  *  b) the Apache License, Version 2.0
  */
+
+#if defined (__clang__)
+#define __ALTIVEC__
+#include "ppc-asm.h"
+#else
 #include <ppc-asm.h>
+#endif
 #include "ppc-opcode.h"
 
 	.section	.data

--- a/barrett_reduction.S
+++ b/barrett_reduction.S
@@ -16,7 +16,9 @@
  */
 
 #if defined (__clang__)
+#ifndef __ALTIVEC__
 #define __ALTIVEC__
+#endif
 #include "ppc-asm.h"
 #else
 #include <ppc-asm.h>

--- a/clang_workaround.h
+++ b/clang_workaround.h
@@ -31,7 +31,11 @@ static inline
 __vector unsigned long long  __builtin_pack_vector (unsigned long __a,
 						    unsigned long __b)
 {
+	#if defined(__BIG_ENDIAN__)
+	__vector unsigned long long __v = {__a, __b};
+	#else
 	__vector unsigned long long __v = {__b, __a};
+	#endif
 	return __v;
 }
 
@@ -44,21 +48,34 @@ unsigned long __builtin_unpack_vector (__vector unsigned long long __v,
 	return __v[__o];
 }
 
+#if defined(__BIG_ENDIAN__)
+#define __builtin_unpack_vector_0(a) __builtin_unpack_vector ((a), 0)
+#define __builtin_unpack_vector_1(a) __builtin_unpack_vector ((a), 1)
+#else
 #define __builtin_unpack_vector_0(a) __builtin_unpack_vector ((a), 1)
 #define __builtin_unpack_vector_1(a) __builtin_unpack_vector ((a), 0)
+#endif
 
 #else
 
 static inline
 unsigned long __builtin_unpack_vector_0 (__vector unsigned long long __v)
 {
+	#if defined(__BIG_ENDIAN__)
+	return vec_xxpermdi(__v, __v, 0x0)[1];
+	#else
 	return vec_xxpermdi(__v, __v, 0x0)[0];
+	#endif
 }
 
 static inline
 unsigned long __builtin_unpack_vector_1 (__vector unsigned long long __v)
 {
+	#if defined(__BIG_ENDIAN__)
+	return vec_xxpermdi(__v, __v, 0x3)[1];
+	#else
 	return vec_xxpermdi(__v, __v, 0x3)[0];
+	#endif
 }
 #endif /* vec_xxpermdi */
 

--- a/clang_workaround.h
+++ b/clang_workaround.h
@@ -1,0 +1,65 @@
+#ifndef CLANG_WORKAROUNDS_H
+#define CLANG_WORKAROUNDS_H
+
+/*
+ * These stubs fix clang incompatibilities with GCC builtins.
+ */
+
+#ifndef __builtin_crypto_vpmsumw
+#define __builtin_crypto_vpmsumw __builtin_crypto_vpmsumb
+#endif
+#ifndef __builtin_crypto_vpmsumd
+#define __builtin_crypto_vpmsumd __builtin_crypto_vpmsumb
+#endif
+
+static inline
+__vector unsigned long long __attribute__((overloadable))
+vec_ld(int __a, const __vector unsigned long long* __b)
+{
+	return (__vector unsigned long long)__builtin_altivec_lvx(__a, __b);
+}
+
+/*
+ * GCC __builtin_pack_vector_int128 returns a vector __int128_t but Clang
+ * does not recognize this type. On GCC this builtin is translated to a
+ * xxpermdi instruction that only moves the registers __a, __b instead generates
+ * a load.
+ *
+ * Clang has vec_xxpermdi intrinsics. It was implemented in 4.0.0.
+ */
+static inline
+__vector unsigned long long  __builtin_pack_vector (unsigned long __a,
+						    unsigned long __b)
+{
+	__vector unsigned long long __v = {__b, __a};
+	return __v;
+}
+
+#ifndef vec_xxpermdi
+
+static inline
+unsigned long __builtin_unpack_vector (__vector unsigned long long __v,
+				       int __o)
+{
+	return __v[__o];
+}
+
+#define __builtin_unpack_vector_0(a) __builtin_unpack_vector ((a), 1)
+#define __builtin_unpack_vector_1(a) __builtin_unpack_vector ((a), 0)
+
+#else
+
+static inline
+unsigned long __builtin_unpack_vector_0 (__vector unsigned long long __v)
+{
+	return vec_xxpermdi(__v, __v, 0x0)[0];
+}
+
+static inline
+unsigned long __builtin_unpack_vector_1 (__vector unsigned long long __v)
+{
+	return vec_xxpermdi(__v, __v, 0x3)[0];
+}
+#endif /* vec_xxpermdi */
+
+#endif

--- a/clang_workaround.h
+++ b/clang_workaround.h
@@ -1,5 +1,5 @@
-#ifndef CLANG_WORKAROUNDS_H
-#define CLANG_WORKAROUNDS_H
+#ifndef CLANG_WORKAROUND_H
+#define CLANG_WORKAROUND_H
 
 /*
  * These stubs fix clang incompatibilities with GCC builtins.

--- a/crc32.S
+++ b/crc32.S
@@ -26,7 +26,13 @@
  *     any later version, or
  *  b) the Apache License, Version 2.0
  */
+
+#if defined (__clang__)
+#define __ALTIVEC__
+#include "ppc-asm.h"
+#else
 #include <ppc-asm.h>
+#endif
 #include "ppc-opcode.h"
 
 #undef toc

--- a/crc32.S
+++ b/crc32.S
@@ -28,7 +28,9 @@
  */
 
 #if defined (__clang__)
+#ifndef __ALTIVEC__
 #define __ALTIVEC__
+#endif
 #include "ppc-asm.h"
 #else
 #include <ppc-asm.h>

--- a/crc32_constants.c
+++ b/crc32_constants.c
@@ -66,7 +66,7 @@ static void do_nonreflected(unsigned int crc, int xor, int assembler, int p8intr
 	printf("#ifdef POWER8_INTRINSICS\n");
 	printf("\n/* Constants */\n");
 	printf("\n/* Reduce %d kbits to 1024 bits */", BLOCKING*8);
-	printf("\nstatic const __vector unsigned long vcrc_const[%d]\n",
+	printf("\nstatic const __vector unsigned long long vcrc_const[%d]\n",
 		((BLOCKING*8)/1024)-1);
 	printf("\t__attribute__((aligned (16))) = {\n");
 	printf("#ifdef __LITTLE_ENDIAN__\n");
@@ -101,7 +101,7 @@ static void do_nonreflected(unsigned int crc, int xor, int assembler, int p8intr
 
 	printf("\n/* Reduce final 1024-2048 bits to 64 bits, shifting 32 bits to "
 		"include the trailing 32 bits of zeros */\n");
-	printf("\nstatic const __vector unsigned long vcrc_short_const[%d]\n",
+	printf("\nstatic const __vector unsigned long long vcrc_short_const[%d]\n",
 		((1024*2)/128));
 	printf("\t__attribute__((aligned (16))) = {\n");
 	printf("#ifdef __LITTLE_ENDIAN__\n");
@@ -143,7 +143,7 @@ static void do_nonreflected(unsigned int crc, int xor, int assembler, int p8intr
 
 	printf("\n/* Barrett constants */\n");
 	printf("/* 33 bit reflected Barrett constant m - (4^32)/n */\n");
-	printf("\nstatic const __vector unsigned long v_Barrett_const[%d]\n"
+	printf("\nstatic const __vector unsigned long long v_Barrett_const[%d]\n"
 		, 2);
 	printf("\t__attribute__((aligned (16))) = {\n");
 	/* Print quotient and Barrett constant. */
@@ -221,7 +221,7 @@ static void do_reflected(unsigned int crc, int xor, int assembler, int p8intrins
 	printf("#ifdef POWER8_INTRINSICS\n");
 	printf("\n/* Constants */\n");
 	printf("\n/* Reduce %d kbits to 1024 bits */", BLOCKING*8);
-	printf("\nstatic const __vector unsigned long vcrc_const[%d]\n",
+	printf("\nstatic const __vector unsigned long long vcrc_const[%d]\n",
 		((BLOCKING*8)/1024)-1);
 	printf("\t__attribute__((aligned (16))) = {\n");
 	printf("#ifdef __LITTLE_ENDIAN__\n");
@@ -258,7 +258,7 @@ static void do_reflected(unsigned int crc, int xor, int assembler, int p8intrins
 
 	printf("\n/* Reduce final 1024-2048 bits to 64 bits, shifting 32 bits to "
 		"include the trailing 32 bits of zeros */\n");
-	printf("\nstatic const __vector unsigned long vcrc_short_const[%d]\n",
+	printf("\nstatic const __vector unsigned long long vcrc_short_const[%d]\n",
 		((1024*2)/128));
 	printf("\t__attribute__((aligned (16))) = {\n");
 	printf("#ifdef __LITTLE_ENDIAN__\n");
@@ -300,7 +300,7 @@ static void do_reflected(unsigned int crc, int xor, int assembler, int p8intrins
 
 	printf("\n/* Barrett constants */\n");
 	printf("/* 33 bit reflected Barrett constant m - (4^32)/n */\n");
-	printf("\nstatic const __vector unsigned long v_Barrett_const[%d]\n"
+	printf("\nstatic const __vector unsigned long long v_Barrett_const[%d]\n"
 		, 2);
 	printf("\t__attribute__((aligned (16))) = {\n");
 	/* Print quotient and Barrett constant. */

--- a/final_fold.S
+++ b/final_fold.S
@@ -21,7 +21,13 @@
  *     any later version, or
  *  b) the Apache License, Version 2.0
  */
+
+#if defined (__clang__)
+#define __ALTIVEC__
+#include "ppc-asm.h"
+#else
 #include <ppc-asm.h>
+#endif
 #include "ppc-opcode.h"
 
 	.section	.data

--- a/final_fold.S
+++ b/final_fold.S
@@ -23,7 +23,9 @@
  */
 
 #if defined (__clang__)
+#ifndef __ALTIVEC__
 #define __ALTIVEC__
+#endif
 #include "ppc-asm.h"
 #else
 #include <ppc-asm.h>

--- a/final_fold2.S
+++ b/final_fold2.S
@@ -21,7 +21,13 @@
  *     any later version, or
  *  b) the Apache License, Version 2.0
  */
+
+#if defined (__clang__)
+#define __ALTIVEC__
+#include "ppc-asm.h"
+#else
 #include <ppc-asm.h>
+#endif
 #include "ppc-opcode.h"
 
 	.section	.data

--- a/final_fold2.S
+++ b/final_fold2.S
@@ -23,7 +23,9 @@
  */
 
 #if defined (__clang__)
+#ifndef __ALTIVEC__
 #define __ALTIVEC__
+#endif
 #include "ppc-asm.h"
 #else
 #include <ppc-asm.h>

--- a/ppc-asm.h
+++ b/ppc-asm.h
@@ -1,0 +1,381 @@
+/* PowerPC asm definitions for GNU C.
+
+Copyright (C) 2002-2017 Free Software Foundation, Inc.
+
+This file is part of GCC.
+
+GCC is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free
+Software Foundation; either version 3, or (at your option) any later
+version.
+
+GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+Under Section 7 of GPL version 3, you are granted additional
+permissions described in the GCC Runtime Library Exception, version
+3.1, as published by the Free Software Foundation.
+
+You should have received a copy of the GNU General Public License and
+a copy of the GCC Runtime Library Exception along with this program;
+see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+<http://www.gnu.org/licenses/>.  */
+
+/* Under winnt, 1) gas supports the following as names and 2) in particular
+   defining "toc" breaks the FUNC_START macro as ".toc" becomes ".2" */
+
+#define r0	0
+#define sp	1
+#define toc	2
+#define r3	3
+#define r4	4
+#define r5	5
+#define r6	6
+#define r7	7
+#define r8	8
+#define r9	9
+#define r10	10
+#define r11	11
+#define r12	12
+#define r13	13
+#define r14	14
+#define r15	15
+#define r16	16
+#define r17	17
+#define r18	18
+#define r19     19
+#define r20	20
+#define r21	21
+#define r22	22
+#define r23	23
+#define r24	24
+#define r25	25
+#define r26	26
+#define r27	27
+#define r28	28
+#define r29	29
+#define r30	30
+#define r31	31
+
+#define cr0	0
+#define cr1	1
+#define cr2	2
+#define cr3	3
+#define cr4	4
+#define cr5	5
+#define cr6	6
+#define cr7	7
+
+#define f0	0
+#define f1	1
+#define f2	2
+#define f3	3
+#define f4	4
+#define f5	5
+#define f6	6
+#define f7	7
+#define f8	8
+#define f9	9
+#define f10	10
+#define f11	11
+#define f12	12
+#define f13	13
+#define f14	14
+#define f15	15
+#define f16	16
+#define f17	17
+#define f18	18
+#define f19	19
+#define f20	20
+#define f21	21
+#define f22	22
+#define f23	23
+#define f24	24
+#define f25	25
+#define f26	26
+#define f27	27
+#define f28	28
+#define f29	29
+#define f30	30
+#define f31	31
+
+#ifdef __VSX__
+#define f32	32
+#define f33	33
+#define f34	34
+#define f35	35
+#define f36	36
+#define f37	37
+#define f38	38
+#define f39	39
+#define f40	40
+#define f41	41
+#define f42	42
+#define f43	43
+#define f44	44
+#define f45	45
+#define f46	46
+#define f47	47
+#define f48	48
+#define f49	49
+#define f50	30
+#define f51	51
+#define f52	52
+#define f53	53
+#define f54	54
+#define f55	55
+#define f56	56
+#define f57	57
+#define f58	58
+#define f59	59
+#define f60	60
+#define f61	61
+#define f62	62
+#define f63	63
+#endif
+
+#ifdef __ALTIVEC__
+#define v0	0
+#define v1	1
+#define v2	2
+#define v3	3
+#define v4	4
+#define v5	5
+#define v6	6
+#define v7	7
+#define v8	8
+#define v9	9
+#define v10	10
+#define v11	11
+#define v12	12
+#define v13	13
+#define v14	14
+#define v15	15
+#define v16	16
+#define v17	17
+#define v18	18
+#define v19	19
+#define v20	20
+#define v21	21
+#define v22	22
+#define v23	23
+#define v24	24
+#define v25	25
+#define v26	26
+#define v27	27
+#define v28	28
+#define v29	29
+#define v30	30
+#define v31	31
+#endif
+
+#ifdef __VSX__
+#define vs0	0
+#define vs1	1
+#define vs2	2
+#define vs3	3
+#define vs4	4
+#define vs5	5
+#define vs6	6
+#define vs7	7
+#define vs8	8
+#define vs9	9
+#define vs10	10
+#define vs11	11
+#define vs12	12
+#define vs13	13
+#define vs14	14
+#define vs15	15
+#define vs16	16
+#define vs17	17
+#define vs18	18
+#define vs19	19
+#define vs20	20
+#define vs21	21
+#define vs22	22
+#define vs23	23
+#define vs24	24
+#define vs25	25
+#define vs26	26
+#define vs27	27
+#define vs28	28
+#define vs29	29
+#define vs30	30
+#define vs31	31
+#define vs32	32
+#define vs33	33
+#define vs34	34
+#define vs35	35
+#define vs36	36
+#define vs37	37
+#define vs38	38
+#define vs39	39
+#define vs40	40
+#define vs41	41
+#define vs42	42
+#define vs43	43
+#define vs44	44
+#define vs45	45
+#define vs46	46
+#define vs47	47
+#define vs48	48
+#define vs49	49
+#define vs50	30
+#define vs51	51
+#define vs52	52
+#define vs53	53
+#define vs54	54
+#define vs55	55
+#define vs56	56
+#define vs57	57
+#define vs58	58
+#define vs59	59
+#define vs60	60
+#define vs61	61
+#define vs62	62
+#define vs63	63
+#endif
+
+/*
+ * Macros to glue together two tokens.
+ */
+
+#ifdef __STDC__
+#define XGLUE(a,b) a##b
+#else
+#define XGLUE(a,b) a/**/b
+#endif
+
+#define GLUE(a,b) XGLUE(a,b)
+
+/*
+ * Macros to begin and end a function written in assembler.  If -mcall-aixdesc
+ * or -mcall-nt, create a function descriptor with the given name, and create
+ * the real function with one or two leading periods respectively.
+ */
+
+#if defined(__powerpc64__) && _CALL_ELF == 2
+
+/* Defining "toc" above breaks @toc in assembler code.  */
+#undef toc
+
+#define FUNC_NAME(name) GLUE(__USER_LABEL_PREFIX__,name)
+#define JUMP_TARGET(name) FUNC_NAME(name)
+#define FUNC_START(name) \
+	.type FUNC_NAME(name),@function; \
+	.globl FUNC_NAME(name); \
+FUNC_NAME(name): \
+0:	addis 2,12,(.TOC.-0b)@ha; \
+	addi 2,2,(.TOC.-0b)@l; \
+	.localentry FUNC_NAME(name),.-FUNC_NAME(name)
+
+#define HIDDEN_FUNC(name) \
+  FUNC_START(name) \
+  .hidden FUNC_NAME(name);
+
+#define FUNC_END(name) \
+	.size FUNC_NAME(name),.-FUNC_NAME(name)
+
+#elif defined (__powerpc64__)
+
+#define FUNC_NAME(name) GLUE(.,name)
+#define JUMP_TARGET(name) FUNC_NAME(name)
+#define FUNC_START(name) \
+	.section ".opd","aw"; \
+name: \
+	.quad GLUE(.,name); \
+	.quad .TOC.@tocbase; \
+	.quad 0; \
+	.previous; \
+	.type GLUE(.,name),@function; \
+	.globl name; \
+	.globl GLUE(.,name); \
+GLUE(.,name):
+
+#define HIDDEN_FUNC(name) \
+  FUNC_START(name) \
+  .hidden name;	\
+  .hidden GLUE(.,name);
+
+#define FUNC_END(name) \
+GLUE(.L,name): \
+	.size GLUE(.,name),GLUE(.L,name)-GLUE(.,name)
+
+#elif defined(_CALL_AIXDESC)
+
+#ifdef _RELOCATABLE
+#define DESC_SECTION ".got2"
+#else
+#define DESC_SECTION ".got1"
+#endif
+
+#define FUNC_NAME(name) GLUE(.,name)
+#define JUMP_TARGET(name) FUNC_NAME(name)
+#define FUNC_START(name) \
+	.section DESC_SECTION,"aw"; \
+name: \
+	.long GLUE(.,name); \
+	.long _GLOBAL_OFFSET_TABLE_; \
+	.long 0; \
+	.previous; \
+	.type GLUE(.,name),@function; \
+	.globl name; \
+	.globl GLUE(.,name); \
+GLUE(.,name):
+
+#define HIDDEN_FUNC(name) \
+  FUNC_START(name) \
+  .hidden name; \
+  .hidden GLUE(.,name);
+
+#define FUNC_END(name) \
+GLUE(.L,name): \
+	.size GLUE(.,name),GLUE(.L,name)-GLUE(.,name)
+
+#else
+
+#define FUNC_NAME(name) GLUE(__USER_LABEL_PREFIX__,name)
+#if defined __PIC__ || defined __pic__
+#define JUMP_TARGET(name) FUNC_NAME(name@plt)
+#else
+#define JUMP_TARGET(name) FUNC_NAME(name)
+#endif
+#define FUNC_START(name) \
+	.type FUNC_NAME(name),@function; \
+	.globl FUNC_NAME(name); \
+FUNC_NAME(name):
+
+#define HIDDEN_FUNC(name) \
+  FUNC_START(name) \
+  .hidden FUNC_NAME(name);
+
+#define FUNC_END(name) \
+GLUE(.L,name): \
+	.size FUNC_NAME(name),GLUE(.L,name)-FUNC_NAME(name)
+#endif
+
+#ifdef IN_GCC
+/* For HAVE_GAS_CFI_DIRECTIVE.  */
+#include "auto-host.h"
+
+#ifdef HAVE_GAS_CFI_DIRECTIVE
+# define CFI_STARTPROC			.cfi_startproc
+# define CFI_ENDPROC			.cfi_endproc
+# define CFI_OFFSET(reg, off)		.cfi_offset reg, off
+# define CFI_DEF_CFA_REGISTER(reg)	.cfi_def_cfa_register reg
+# define CFI_RESTORE(reg)		.cfi_restore reg
+#else
+# define CFI_STARTPROC
+# define CFI_ENDPROC
+# define CFI_OFFSET(reg, off)
+# define CFI_DEF_CFA_REGISTER(reg)
+# define CFI_RESTORE(reg)
+#endif
+#endif
+
+#if defined __linux__
+	.section .note.GNU-stack
+	.previous
+#endif

--- a/vec_barrett_reduction.c
+++ b/vec_barrett_reduction.c
@@ -19,8 +19,42 @@
 #include <stdint.h>
 #include <altivec.h>
 
+/*
+ * Those stubs fix clang incompatibilitie issues with GCC builtins.
+ */
+#if defined (__clang__)
+#define __builtin_crypto_vpmsumw __builtin_crypto_vpmsumb
+#define __builtin_crypto_vpmsumd __builtin_crypto_vpmsumb
+
+__vector unsigned long long __attribute__((overloadable))
+vec_ld(int __a, const __vector unsigned long long* __b)
+{
+	return (__vector unsigned long long)__builtin_altivec_lvx(__a, __b);
+}
+
+/*
+ * GCC __builtin_pack_vector_int128 returns a vector __int128_t but Clang
+ * seems to not recognize this type. On GCC this builtin is translated to a
+ * xxpermdi instruction that only move the registers __a, __b instead generates
+ * a load. Clang doesn't have this builtin or xxpermdi intrinsics. Was recently
+ * implemented https://reviews.llvm.org/rL303760.
+ * */
+__vector unsigned long long  __builtin_pack_vector (unsigned long __a,
+												    unsigned long __b)
+{
+	__vector unsigned long long __v = {__a, __b};
+	return __v;
+}
+
+unsigned long __builtin_unpack_vector (__vector unsigned long long __v,
+									   int __o)
+{
+	return __v[__o];
+}
+#endif
+
 #if defined(__LITTLE_ENDIAN__)
-static const __vector unsigned long v_Barrett_const[2]
+static const __vector unsigned long long v_Barrett_const[2]
 	 __attribute__ ((aligned (16))) = {
 		/* Barrett constant m - (4^32)/n */
 		{ 0x0000000104d101dfUL, 0x0000000000000000UL },
@@ -28,7 +62,7 @@ static const __vector unsigned long v_Barrett_const[2]
 		{ 0x0000000104c11db7UL, 0x0000000000000000UL }
 	};
 
-static const __vector unsigned long v_Barrett_reflect_const[2]
+static const __vector unsigned long long v_Barrett_reflect_const[2]
 	__attribute__ ((aligned (16))) = {
 		/* Barrett constant m - (4^32)/n */
 		{ 0x00000001f7011641UL, 0x0000000000000000UL },
@@ -36,7 +70,7 @@ static const __vector unsigned long v_Barrett_reflect_const[2]
 		{ 0x00000001db710641UL, 0x0000000000000000UL }
 	};
 #else
-static const __vector unsigned long v_Barrett_const[2]
+static const __vector unsigned long long v_Barrett_const[2]
 	__attribute__ ((aligned (16))) = {
 		/* Barrett constant m - (4^32)/n */
 		{ 0x0000000000000000UL, 0x0000000104d101dfUL },
@@ -44,7 +78,7 @@ static const __vector unsigned long v_Barrett_const[2]
 		{ 0x0000000000000000UL, 0x0000000104c11db7UL  }
 	};
 
-static const __vector unsigned long v_Barrett_reflect_const[2]
+static const __vector unsigned long long v_Barrett_reflect_const[2]
 	 __attribute__ ((aligned (16))) = {
 		/* Barrett constant m - (4^32)/n */
 		{ 0x0000000000000000UL, 0x00000001f7011641UL },
@@ -55,17 +89,22 @@ static const __vector unsigned long v_Barrett_reflect_const[2]
 
 unsigned long __attribute__ ((aligned (32)))
 barrett_reduction (unsigned long data){
-	const __vector unsigned long vzero = {0,0};
-	__vector unsigned long vconst1 = vec_ld(0, v_Barrett_const);
-	__vector unsigned long vconst2 = vec_ld(16, v_Barrett_const);
+	const __vector unsigned long long vzero = {0,0};
 
-	__vector unsigned long vdata, v0;
+	__vector unsigned long long vconst1 = vec_ld(0, v_Barrett_const);
+	__vector unsigned long long vconst2 = vec_ld(16,v_Barrett_const);
+
+	__vector unsigned long long v0;
 
 	unsigned long result = 0;
 
 	/* Get (unsigned long) a into vdata */
-	vdata = (__vector unsigned long)__builtin_pack_vector_int128(0UL, data);
-
+	#if defined(__clang__)
+	__vector unsigned long long vdata =  __builtin_pack_vector(data, 0UL);
+	#else
+	__vector unsigned long long vdata = (__vector unsigned long long)
+			__builtin_pack_vector_int128(0UL, data);
+	#endif
 	/*
 	 * Now for the actual algorithm. The idea is to calculate q,
 	 * the multiple of our polynomial that we need to subtract. By
@@ -73,14 +112,14 @@ barrett_reduction (unsigned long data){
 	 * result back down 2x bits, we round down to the nearest multiple.
 	 */
 	/* ma */
-	v0 = __builtin_crypto_vpmsumd ((__vector unsigned long)vdata,
-			(__vector unsigned long)vconst1);
+	v0 = __builtin_crypto_vpmsumd ((__vector unsigned long long)vdata,
+			(__vector unsigned long long)vconst1);
 	/* q = floor(ma/(2^64)) */
-	v0 = (__vector unsigned long)vec_sld ((__vector unsigned char)vzero,
+	v0 = (__vector unsigned long long)vec_sld ((__vector unsigned char)vzero,
 			(__vector unsigned char)v0, 8);
 	/* qn */
-	v0 = __builtin_crypto_vpmsumd ((__vector unsigned long)v0,
-			(__vector unsigned long)vconst2);
+	v0 = __builtin_crypto_vpmsumd ((__vector unsigned long long)v0,
+			(__vector unsigned long long)vconst2);
 	/* a - qn, subtraction is xor in GF(2) */
 	v0 = vec_xor (vdata, v0);
 	/*
@@ -88,31 +127,40 @@ barrett_reduction (unsigned long data){
 	 * V0 [ 0 1 2 X ]
 	 * V0 [ 0 X 2 3 ]
 	 */
-
+	#if defined (__clang__)
+	result = __builtin_unpack_vector(v0, 0);
+	#else
 	result = __builtin_unpack_vector_int128 ((vector __int128_t)v0, 1);
+	#endif
 
 	return result;
 }
 
 unsigned long __attribute__ ((aligned (32)))
 barrett_reduction_reflected (unsigned long data){
-	const __vector unsigned long vzero = {0,0};
-	const __vector unsigned long vones = {0xffffffffffffffffUL,
-												0xffffffffffffffffUL};
-	const __vector unsigned long vmask_32bit =
-		(__vector unsigned long)vec_sld((__vector unsigned char)vzero,
+
+	const __vector unsigned long long vzero = {0,0};
+	const __vector unsigned long long vones = {0xffffffffffffffffUL,
+											   0xffffffffffffffffUL};
+
+	const __vector unsigned long long vmask_32bit =
+		(__vector unsigned long long)vec_sld((__vector unsigned char)vzero,
 			(__vector unsigned char)vones, 4);
 
-	__vector unsigned long vconst1 = vec_ld(0, v_Barrett_reflect_const);
-	__vector unsigned long vconst2 = vec_ld(16, v_Barrett_reflect_const);
+	__vector unsigned long long vconst1 = vec_ld(0, v_Barrett_reflect_const);
+	__vector unsigned long long vconst2 = vec_ld(16,v_Barrett_reflect_const);
 
-	__vector unsigned long vdata, v0;
+	__vector unsigned long long v0;
 
 	unsigned long result = 0;
 
 	/* Get (unsigned long) a into vdata */
-	vdata = (__vector unsigned long)__builtin_pack_vector_int128(0UL, data);
-
+	#if defined(__clang__)
+	__vector unsigned long long vdata = __builtin_pack_vector(data, 0UL);
+	#else
+	__vector unsigned long long vdata = (__vector unsigned long long)
+			__builtin_pack_vector_int128(0UL, data);
+	#endif
 	/*
 	 * Now for the actual algorithm. The idea is to calculate q,
 	 * the multiple of our polynomial that we need to subtract. By
@@ -122,13 +170,13 @@ barrett_reduction_reflected (unsigned long data){
 	/* bottom 32 bits of a */
 	v0 = vec_and (vdata, vmask_32bit);
 	/* ma */
-	v0 = __builtin_crypto_vpmsumd ((__vector unsigned long)v0,
-			(__vector unsigned long)vconst1);
+	v0 = __builtin_crypto_vpmsumd ((__vector unsigned long long)vdata,
+			(__vector unsigned long long)vconst1);
 	/* bottom 32 bits of a */
 	v0 = vec_and (v0, vmask_32bit);
 	/* qn */
-	v0 = __builtin_crypto_vpmsumd ((__vector unsigned long)v0,
-			(__vector unsigned long)vconst2);
+	v0 = __builtin_crypto_vpmsumd ((__vector unsigned long long)v0,
+			(__vector unsigned long long)vconst2);
 	/* a - qn, subtraction is xor in GF(2) */
 	v0 = vec_xor (vdata, v0);
 	/*
@@ -137,9 +185,13 @@ barrett_reduction_reflected (unsigned long data){
 		 * V0 [ 0 1 X 3 ]
 		 * V0 [ 0 X 2 3 ]
 		 */
-	v0 = (__vector unsigned long)vec_sld((__vector unsigned char)v0,
+	v0 = (__vector unsigned long long )vec_sld((__vector unsigned char)v0,
 			(__vector unsigned char)vzero, 4);
+	#if defined (__clang__)
+	result = __builtin_unpack_vector (v0, 1);
+	#else
 	result = __builtin_unpack_vector_int128 ((vector __int128_t)v0, 0);
+	#endif
 
 	return result;
 }

--- a/vec_crc32.c
+++ b/vec_crc32.c
@@ -44,7 +44,7 @@
 #define VMX_ALIGN_MASK	(VMX_ALIGN-1)
 
 #ifdef REFLECT
-static unsigned int crc32_align(unsigned int crc, unsigned char *p,
+static unsigned int crc32_align(unsigned int crc, const unsigned char *p,
 			       unsigned long len)
 {
 	while (len--)
@@ -52,7 +52,7 @@ static unsigned int crc32_align(unsigned int crc, unsigned char *p,
 	return crc;
 }
 #else
-static unsigned int crc32_align(unsigned int crc, unsigned char *p,
+static unsigned int crc32_align(unsigned int crc, const unsigned char *p,
 				unsigned long len)
 {
 	while (len--)
@@ -62,13 +62,13 @@ static unsigned int crc32_align(unsigned int crc, unsigned char *p,
 #endif
 
 static unsigned int __attribute__ ((aligned (32)))
-__crc32_vpmsum(unsigned int crc, void* p, unsigned long len);
+__crc32_vpmsum(unsigned int crc, const void* p, unsigned long len);
 
 #ifndef CRC32_FUNCTION
 #define CRC32_FUNCTION  crc32_vpmsum
 #endif
 
-unsigned int CRC32_FUNCTION(unsigned int crc, unsigned char *p,
+unsigned int CRC32_FUNCTION(unsigned int crc, const unsigned char *p,
 			    unsigned long len)
 {
 	unsigned int prealign;
@@ -144,7 +144,7 @@ static const __vector unsigned long long vperm_const
 #endif
 
 static unsigned int __attribute__ ((aligned (32)))
-__crc32_vpmsum(unsigned int crc, void* p, unsigned long len) {
+__crc32_vpmsum(unsigned int crc, const void* p, unsigned long len) {
 
 	const __vector unsigned long long vzero = {0,0};
 	const __vector unsigned long long vones = {0xffffffffffffffffUL,

--- a/vec_crc32.c
+++ b/vec_crc32.c
@@ -185,8 +185,8 @@ __crc32_vpmsum(unsigned int crc, const void* p, unsigned long len) {
 	unsigned int result = 0;
 	unsigned int offset; /* Constant table offset. */
 
-	long i; /* Counter. */
-	long chunks;
+	unsigned long i; /* Counter. */
+	unsigned long chunks;
 
 	unsigned long block_size;
 	int next_block = 0;
@@ -258,7 +258,7 @@ __crc32_vpmsum(unsigned int crc, const void* p, unsigned long len) {
 		/* xor in initial value */
 		vdata0 = vec_xor(vdata0, vcrc);
 
-		p += 128;
+		p = (char *)p + 128;
 
 		do {
 			/* Checksum in blocks of MAX_SIZE. */
@@ -326,14 +326,14 @@ __crc32_vpmsum(unsigned int crc, const void* p, unsigned long len) {
 				vdata7 = vec_ld(112, (__vector unsigned long long*) p);
 				VEC_PERM(vdata7, vdata7, vdata7, vperm_const);
 
-				p += 128;
+				p = (char *)p + 128;
 
 				/*
 				 * main loop. We modulo schedule it such that it takes three
 				 * iterations to complete - first iteration load, second
 				 * iteration vpmsum, third iteration xor.
 				 */
-				for (i = 0; i < chunks-2; i++, p += 128) {
+				for (i = 0; i < chunks-2; i++) {
 					vconst1 = vec_ld(offset, vcrc_const);
 					offset += 16;
 					GROUP_ENDING_NOP;
@@ -394,6 +394,8 @@ __crc32_vpmsum(unsigned int crc, const void* p, unsigned long len) {
 							long)vdata7, (__vector unsigned long long)vconst1);
 					vdata7 = vec_ld(112, (__vector unsigned long long*) p);
 					VEC_PERM(vdata7, vdata7, vdata7, vperm_const);
+
+					p = (char *)p + 128;
 				}
 
 				/* First cool down*/
@@ -500,7 +502,7 @@ __crc32_vpmsum(unsigned int crc, const void* p, unsigned long len) {
 			va7 = vec_ld(112, (__vector unsigned long long*) p);
 			VEC_PERM(va7, va7, va7, vperm_const);
 
-			p += 128;
+			p = (char *)p + 128;
 
 			vdata0 = vec_xor(v0, va0);
 			vdata1 = vec_xor(v1, va1);

--- a/vec_final_fold2.c
+++ b/vec_final_fold2.c
@@ -24,8 +24,42 @@
  */
 #include <altivec.h>
 
+/*
+ * Those stubs fix clang incompatibilitie issues with GCC builtins.
+ */
+#if defined (__clang__)
+#define __builtin_crypto_vpmsumw __builtin_crypto_vpmsumb
+#define __builtin_crypto_vpmsumd __builtin_crypto_vpmsumb
+
+__vector unsigned long long __attribute__((overloadable))
+vec_ld(int __a, const __vector unsigned long long* __b)
+{
+	return (__vector unsigned long long)__builtin_altivec_lvx(__a, __b);
+}
+
+/*
+ * GCC __builtin_pack_vector_int128 returns a vector __int128_t but Clang
+ * seems to not recognize this type. On GCC this builtin is translated to a
+ * xxpermdi instruction that only move the registers __a, __b instead generates
+ * a load. Clang doesn't have this builtin or xxpermdi intrinsics. Was recently
+ * implemented https://reviews.llvm.org/rL303760.
+ * */
+__vector unsigned long long  __builtin_pack_vector (unsigned long __a,
+												    unsigned long __b)
+{
+	__vector unsigned long long __v = {__a, __b};
+	return __v;
+}
+
+unsigned long __builtin_unpack_vector (__vector unsigned long long __v,
+									   int __o)
+{
+	return __v[__o];
+}
+#endif
+
 #if defined(__LITTLE_ENDIAN__)
-static const __vector unsigned long vfold2_const[4]
+static const __vector unsigned long long vfold2_const[4]
 	__attribute__ ((aligned (16))) = {
 		/* x^128 mod p(x), x^96 mod p(x), x^64 mod p(x), x^32 mod p(x) */
 		{ 0x490d678d04c11db7UL, 0xe8a45605f200aa66UL },
@@ -37,7 +71,7 @@ static const __vector unsigned long vfold2_const[4]
 		{ 0x08090A0B0C0D0E0FUL, 0x0001020304050607UL }
 	};
 
-static const __vector unsigned long vfold2_reflect_const[4]
+static const __vector unsigned long long vfold2_reflect_const[4]
 	__attribute__ ((aligned (16))) = {
 		/* x^32 mod p(x)`, x^64 mod p(x)`, x^96 mod p(x)`, x^128 mod p(x)` */
 		{ 0x6655004fa06a2517UL, 0xedb88320b1e6b092UL },
@@ -49,7 +83,7 @@ static const __vector unsigned long vfold2_reflect_const[4]
 		{ 0x08090A0B0C0D0E0FUL, 0x0001020304050607UL }
 	};
 #else
-static const __vector unsigned long vfold2_const[4]
+static const __vector unsigned long long vfold2_const[4]
 	 __attribute__ ((aligned (16))) = {
 		/* x^128 mod p(x), x^96 mod p(x), x^64 mod p(x), x^32 mod p(x) */
 		{ 0xe8a45605f200aa66UL, 0x490d678d04c11db7UL },
@@ -61,7 +95,7 @@ static const __vector unsigned long vfold2_const[4]
 		{ 0x0F0E0D0C0B0A0908UL, 0X0706050403020100UL }
 	};
 
-static const __vector unsigned long vfold2_reflect_const[4]
+static const __vector unsigned long long vfold2_reflect_const[4]
 	__attribute__ ((aligned (16))) = {
 		/* x^32 mod p(x)`, x^64 mod p(x)`, x^96 mod p(x)`, x^128 mod p(x)` */
 		{ 0xedb88320b1e6b092UL, 0x6655004fa06a2517UL },
@@ -77,32 +111,34 @@ static const __vector unsigned long vfold2_reflect_const[4]
 unsigned long  __attribute__ ((aligned (32)))
 final_fold2(void *__restrict__ data) {
 
-	const __vector unsigned long vzero = {0,0};
-	const __vector unsigned long vones = {0xffffffffffffffffUL,
+	const __vector unsigned long long vzero = {0,0};
+	const __vector unsigned long long vones = {0xffffffffffffffffUL,
 											0xffffffffffffffffUL};
 
-	const __vector unsigned long vmask_64bit =
-		(__vector unsigned long)vec_sld((__vector unsigned char)vzero,
+	const __vector unsigned long long vmask_64bit =
+		(__vector unsigned long long)vec_sld((__vector unsigned char)vzero,
 			(__vector unsigned char)vones, 8);
 
-	__vector unsigned long vconst1 = vec_ld(0, vfold2_const);
-	__vector unsigned long vconst2 = vec_ld(16, vfold2_const);
-	__vector unsigned long vconst3 = vec_ld(32, vfold2_const);
+	__vector unsigned long long vconst1 = vec_ld(0, vfold2_const);
+	__vector unsigned long long vconst2 = vec_ld(16, vfold2_const);
+	__vector unsigned long long vconst3 = vec_ld(32, vfold2_const);
 
-	__vector unsigned long long vdata, v0, v1;
+	__vector unsigned long long  vdata, v0, v1;
 
 	unsigned long result = 0;
 
-	vdata = vec_ld(0, (__vector unsigned long*) data);
+	vdata = vec_ld(0, (__vector unsigned long long*) data);
+
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-	__vector unsigned long vperm_const = vec_ld(48, vfold2_const);
+	__vector unsigned long long vperm_const = vec_ld(48, vfold2_const);
 	vdata = vec_perm (vdata, vdata, (__vector unsigned char)vperm_const);
 #endif
 
-	v0 = (__vector unsigned long)__builtin_crypto_vpmsumw (
-			(__vector unsigned int)vdata, (__vector unsigned int)vconst1);
+	v0 = (__vector unsigned long long)__builtin_crypto_vpmsumw (
+			(__vector unsigned int)vdata,(__vector unsigned int)vconst1);
+
 	/* xor two 64 bit results together */
-	v1 = (__vector unsigned long)vec_sld((__vector unsigned char)v0,
+	v1 = (__vector unsigned long long)vec_sld((__vector unsigned char)v0,
 			(__vector unsigned char)v0, 8);
 	v0 = vec_xor (v1, v0);
 	v0 = vec_and (v0, vmask_64bit);
@@ -114,14 +150,15 @@ final_fold2(void *__restrict__ data) {
 	 * result back down 2x bits, we round down to the nearest multiple.
 	 */
 	/* ma */
-	v1 = __builtin_crypto_vpmsumd ((__vector unsigned long)v0,
-			(__vector unsigned long)vconst2);
+	v1 = __builtin_crypto_vpmsumd ((__vector unsigned long long)v0,
+			(__vector unsigned long long)vconst2);
 	/* q = floor(ma/(2^64)) */
-	v1 = (__vector unsigned long)vec_sld ((__vector unsigned char)vzero,
+	v1 = (__vector unsigned long long)vec_sld ((__vector unsigned char)vzero,
 			(__vector unsigned char)v1, 8);
 	/* qn */
-	v1 = __builtin_crypto_vpmsumd ((__vector unsigned long)v1,
-			(__vector unsigned long)vconst3);
+	v1 = __builtin_crypto_vpmsumd ((__vector unsigned long long)v1,
+			(__vector unsigned long long)vconst3);
+
 	 /* a - qn, subtraction is xor in GF(2) */
 	v0 = vec_xor (v1, v0);
 	/*
@@ -129,37 +166,41 @@ final_fold2(void *__restrict__ data) {
 	 * V0 [ 0 1 2 X ]
 	 * V0 [ 0 X 2 3 ]
 	 */
+#if defined (__clang__)
+	result = __builtin_unpack_vector (v0, 0);
+#else
 	result = __builtin_unpack_vector_int128 ((vector __int128_t)v0, 1);
-
+#endif
 	return result;
 }
 
 unsigned long  __attribute__ ((aligned (32)))
 final_fold2_reflected(void *__restrict__ data) {
-	const __vector unsigned long vzero = {0,0};
-	const __vector unsigned long vones = {0xffffffffffffffffUL,
+	const __vector unsigned long long vzero = {0,0};
+	const __vector unsigned long long vones = {0xffffffffffffffffUL,
 											0xffffffffffffffffUL};
-	const __vector unsigned long vmask_32bit =
-		(__vector unsigned long)vec_sld((__vector unsigned char)vzero,
+	const __vector unsigned long long vmask_32bit =
+		(__vector unsigned long long)vec_sld((__vector unsigned char)vzero,
 			(__vector unsigned char)vones, 4);
-	const __vector unsigned long vmask_64bit =
-		(__vector unsigned long)vec_sld((__vector unsigned char)vzero,
+	const __vector unsigned long long vmask_64bit =
+		(__vector unsigned long long)vec_sld((__vector unsigned char)vzero,
 			(__vector unsigned char)vones, 8);
 
-    __vector unsigned long vconst1 = vec_ld(0, vfold2_reflect_const);
-    __vector unsigned long vconst2 = vec_ld(16, vfold2_reflect_const);
-    __vector unsigned long vconst3 = vec_ld(32, vfold2_reflect_const);
+	__vector unsigned long long vconst1 = vec_ld(0, vfold2_reflect_const);
+	__vector unsigned long long vconst2 = vec_ld(16, vfold2_reflect_const);
+	__vector unsigned long long vconst3 = vec_ld(32, vfold2_reflect_const);
 
 	/* shift left one bit */
 	__vector unsigned char vsht_splat = vec_splat_u8 (1);
 
-	__vector unsigned long vdata, v0, v1;
+	__vector unsigned long long vdata, v0, v1;
 
 	unsigned long result = 0;
 
-	vdata = vec_ld(0, (__vector unsigned long*) data);
+	vdata = vec_ld(0, (__vector unsigned long long*) data);
+
 #if __BYTE_ORDER__ != __ORDER_LITTLE_ENDIAN__
-	__vector unsigned long vperm_const = vec_ld(48, vfold2_reflect_const);
+	__vector unsigned long long vperm_const = vec_ld(48, vfold2_reflect_const);
 	vdata = vec_perm (vdata, vdata, (__vector unsigned char)vperm_const);
 #endif
 
@@ -169,14 +210,15 @@ final_fold2_reflected(void *__restrict__ data) {
 	 * bits on the right side (ie the lower bits) and xor'ing them
 	 * on the left side.
 	 */
-	v0 = (__vector unsigned long)__builtin_crypto_vpmsumw (
+	v0 = (__vector unsigned long long)__builtin_crypto_vpmsumw (
 			(__vector unsigned int)vdata,(__vector unsigned int)vconst1);
+
 	/* xor two 64 bit results together */
-	v1 = (__vector unsigned long)vec_sld ((__vector unsigned char)v0,
+	v1 = (__vector unsigned long long)vec_sld ((__vector unsigned char)v0,
 			(__vector unsigned char)v0, 8);
 	v0 = vec_xor (v1, v0);
 
-	v0 = (__vector unsigned long)vec_sll ((__vector unsigned char)v0,
+	v0 = (__vector unsigned long long)vec_sll ((__vector unsigned char)v0,
 			vsht_splat);
 
 	v0 = vec_and (v0, vmask_64bit);
@@ -190,13 +232,15 @@ final_fold2_reflected(void *__restrict__ data) {
 	/* bottom 32 bits of a */
 	v1 = vec_and (v0, vmask_32bit);
 	/* ma */
-	v1 = __builtin_crypto_vpmsumd ((__vector unsigned long)v1,
-			(__vector unsigned long)vconst2);
+	v1 = __builtin_crypto_vpmsumd ((__vector unsigned long long)v1,
+			(__vector unsigned long long)vconst2);
+
 	/* bottom 32 bits of ma */
 	v1 = vec_and (v1, vmask_32bit);
 	/* qn */
-	v1 = __builtin_crypto_vpmsumd ((__vector unsigned long)v1,
-			(__vector unsigned long)vconst3);
+	v1 = __builtin_crypto_vpmsumd ((__vector unsigned long long)v1,
+			(__vector unsigned long long)vconst3);
+
 	/* a - qn, subtraction is xor in GF(2) */
 	v0 = vec_xor (v0, v1);
 	/*
@@ -204,9 +248,14 @@ final_fold2_reflected(void *__restrict__ data) {
 	 * V0 [ 0 1 2 X ]
 	 * V0 [ 0 X 2 3 ]
 	 */
-	v0 = (__vector unsigned long)vec_sld ((__vector unsigned char)v0,
+	v0 = (__vector unsigned long long)vec_sld ((__vector unsigned char)v0,
 			(__vector unsigned char)vzero, 4);
+
+#if defined (__clang__)
+	result = __builtin_unpack_vector (v0, 1);
+#else
 	result = __builtin_unpack_vector_int128 ((vector __int128_t)v0, 0);
+#endif
 
 	return result;
 }

--- a/vec_final_fold2.c
+++ b/vec_final_fold2.c
@@ -24,38 +24,12 @@
  */
 #include <altivec.h>
 
-/*
- * Those stubs fix clang incompatibilitie issues with GCC builtins.
- */
 #if defined (__clang__)
-#define __builtin_crypto_vpmsumw __builtin_crypto_vpmsumb
-#define __builtin_crypto_vpmsumd __builtin_crypto_vpmsumb
-
-__vector unsigned long long __attribute__((overloadable))
-vec_ld(int __a, const __vector unsigned long long* __b)
-{
-	return (__vector unsigned long long)__builtin_altivec_lvx(__a, __b);
-}
-
-/*
- * GCC __builtin_pack_vector_int128 returns a vector __int128_t but Clang
- * seems to not recognize this type. On GCC this builtin is translated to a
- * xxpermdi instruction that only move the registers __a, __b instead generates
- * a load. Clang doesn't have this builtin or xxpermdi intrinsics. Was recently
- * implemented https://reviews.llvm.org/rL303760.
- * */
-__vector unsigned long long  __builtin_pack_vector (unsigned long __a,
-												    unsigned long __b)
-{
-	__vector unsigned long long __v = {__a, __b};
-	return __v;
-}
-
-unsigned long __builtin_unpack_vector (__vector unsigned long long __v,
-									   int __o)
-{
-	return __v[__o];
-}
+#include "clang_workaround.h"
+#else
+#define __builtin_pack_vector(a, b)  __builtin_pack_vector_int128 ((a), (b))
+#define __builtin_unpack_vector_0(a) __builtin_unpack_vector_int128 ((vector __int128_t)(a), 0)
+#define __builtin_unpack_vector_1(a) __builtin_unpack_vector_int128 ((vector __int128_t)(a), 1)
 #endif
 
 #if defined(__LITTLE_ENDIAN__)
@@ -166,11 +140,8 @@ final_fold2(void *__restrict__ data) {
 	 * V0 [ 0 1 2 X ]
 	 * V0 [ 0 X 2 3 ]
 	 */
-#if defined (__clang__)
-	result = __builtin_unpack_vector (v0, 0);
-#else
-	result = __builtin_unpack_vector_int128 ((vector __int128_t)v0, 1);
-#endif
+	result = __builtin_unpack_vector_1 (v0);
+
 	return result;
 }
 
@@ -251,11 +222,7 @@ final_fold2_reflected(void *__restrict__ data) {
 	v0 = (__vector unsigned long long)vec_sld ((__vector unsigned char)v0,
 			(__vector unsigned char)vzero, 4);
 
-#if defined (__clang__)
-	result = __builtin_unpack_vector (v0, 1);
-#else
-	result = __builtin_unpack_vector_int128 ((vector __int128_t)v0, 0);
-#endif
+	result = __builtin_unpack_vector_0 (v0);
 
 	return result;
 }


### PR DESCRIPTION
+ few more length tests.
+ compile error fixes
+ long -> long long for strictness (clang doesn't do vector long operations, only long long)
+ const ptr since contents aren't modified. should make it easier to drop in.